### PR TITLE
keep leading and trailing whitespace

### DIFF
--- a/pkg/R/oo.R
+++ b/pkg/R/oo.R
@@ -47,7 +47,7 @@ Logger <- setRefClass("Logger",
                           invisible(TRUE)
                         },
 
-                        log = function(msglevel, msg, ...) {
+                        log = function(msglevel, msg, keep.space = FALSE, ...) {
                           if (msglevel < level) {
                             return(invisible(FALSE))
                           }
@@ -82,8 +82,10 @@ Logger <- setRefClass("Logger",
                           }
 
                           ## strip leading and trailing whitespace from the final message.
-                          msg <- sub("[[:space:]]+$", '', msg)
-                          msg <- sub("^[[:space:]]+", '', msg)
+                          if (!keep.space) {
+                              msg <- sub("[[:space:]]+$", '', msg)
+                              msg <- sub("^[[:space:]]+", '', msg)
+                          }
                           record$msg <- msg
 
                           record$timestamp <- sprintf("%s", Sys.time())

--- a/pkg/R/oo.R
+++ b/pkg/R/oo.R
@@ -47,7 +47,7 @@ Logger <- setRefClass("Logger",
                           invisible(TRUE)
                         },
 
-                        log = function(msglevel, msg, keep.space = FALSE, ...) {
+                        log = function(msglevel, msg, ..., keep.space = FALSE) {
                           if (msglevel < level) {
                             return(invisible(FALSE))
                           }


### PR DESCRIPTION
add an optional argument - keep.space. When it is true, the leading and trailing whitespaces are preserved. 

To be compatible with the old version, this argument's value is set to FALSE by default.

I don't know how to write test for the unittest framework used in this package, here's the tests I did. I guess it might be easy to integrate them into the unittest?  

``` R
R> basicConfig()
R> loginfo("a")
2016-08-31 10:22:19 INFO::a
R> loginfo("   a")
2016-08-31 10:22:20 INFO::a
R> loginfo("   a", keep.space=T)
2016-08-31 10:22:23 INFO::   a
R> loginfo("\t\ta", keep.space=T)
2016-08-31 10:22:44 INFO::      a
```

``` R
R> loginfo("\t%s %f", "Pi is about", pi)
2016-08-31 10:31:01 INFO::Pi is about 3.141593
R> loginfo("\t%s %f", "Pi is about", pi, keep.space=F)
2016-08-31 10:31:07 INFO::Pi is about 3.141593
R> loginfo("\t%s %f", "Pi is about", pi, keep.space=T)
2016-08-31 10:31:15 INFO::  Pi is about 3.141593
```
