### PR TITLE
Fixes https://github.com/WLOGSolutions/r-logging/issues/2

### DIFF
--- a/pkg/R/oo.R
+++ b/pkg/R/oo.R
@@ -67,6 +67,8 @@ Logger <- setRefClass(
                                 x <- paste(x, collapse = ",")
                               x
                             })
+        } else {
+          optargs <- list(fmt="%s")
         }
         msg <- do.call("sprintf", c(msg, optargs))
       } else {


### PR DESCRIPTION
Hi,

I may have fixed this: (https://github.com/WLOGSolutions/r-logging/issues/2). The error occurs because `logger(x)` calls `sprintf(fmt = x)`, which I doubt is the intended behaviour. I think the correct behaviour is to call `sprintf(fmt = "%s", x)`.

Cheers, 
Nikhil